### PR TITLE
Allow multiple MQTT brokers

### DIFF
--- a/cmd/lora-gateway-bridge/cmd/configfile.go
+++ b/cmd/lora-gateway-bridge/cmd/configfile.go
@@ -223,6 +223,12 @@ marshaler="{{ .Integration.Marshaler }}"
     # MQTT server (e.g. scheme://host:port where scheme is tcp, ssl or ws)
     server="{{ .Integration.MQTT.Auth.Generic.Server }}"
 
+    # MQTT servers (e.g. scheme://host:port where scheme is tcp, ssl or ws)
+    # Allows for multiple broker connections - Overrides server if not empty
+    servers=[{{ range $index, $elm := .Integration.MQTT.Auth.Generic.Servers }}
+      "{{ $elm }}",{{ end }}
+    ]
+
     # Connect with the given username (optional)
     username="{{ .Integration.MQTT.Auth.Generic.Username }}"
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -62,15 +62,16 @@ type Config struct {
 				Type string `mapstructure:"type"`
 
 				Generic struct {
-					Server       string `mapstructure:"server"`
-					Username     string `mapstructure:"username"`
-					Password     string `mapstrucure:"password"`
-					CACert       string `mapstructure:"ca_cert"`
-					TLSCert      string `mapstructure:"tls_cert"`
-					TLSKey       string `mapstructure:"tls_key"`
-					QOS          uint8  `mapstructure:"qos"`
-					CleanSession bool   `mapstructure:"clean_session"`
-					ClientID     string `mapstructure:"client_id"`
+					Server       string   `mapstructure:"server"`
+					Servers      []string `mapstructure:"servers"`
+					Username     string   `mapstructure:"username"`
+					Password     string   `mapstrucure:"password"`
+					CACert       string   `mapstructure:"ca_cert"`
+					TLSCert      string   `mapstructure:"tls_cert"`
+					TLSKey       string   `mapstructure:"tls_key"`
+					QOS          uint8    `mapstructure:"qos"`
+					CleanSession bool     `mapstructure:"clean_session"`
+					ClientID     string   `mapstructure:"client_id"`
 				} `mapstructure:"generic"`
 
 				GCPCloudIoTCore struct {


### PR DESCRIPTION
Partially covers #93 

Add a new config option `servers` for a list of MQTT brokers to connect to and fall back to existing `server` option if `servers` is empty/unset.

Left default of using `server` alone, as I didn't want to break existing configurations by adding a non-empty default to `servers`.