### PR TITLE
MQTT LWT Support

### DIFF
--- a/cmd/chirpstack-gateway-bridge/cmd/configfile.go
+++ b/cmd/chirpstack-gateway-bridge/cmd/configfile.go
@@ -271,6 +271,25 @@ marshaler="{{ .Integration.Marshaler }}"
     # mqtt TLS key file (optional)
     tls_key="{{ .Integration.MQTT.Auth.Generic.TLSKey }}"
 
+      # Last Will and Testament
+      #
+      # A message is pre-queued to the broker and is automatically sent in the event of an ungraceful disconnect
+      [integration.mqtt.auth.generic.lwt]
+      # Enable LWT message
+      enable={{ .Integration.MQTT.Auth.Generic.LWT.Enable }}
+
+      # LWT Message Topic
+      topic="{{ .Integration.MQTT.Auth.Generic.LWT.Topic }}"
+
+      # LWT Message Payload String
+      payload="{{ .Integration.MQTT.Auth.Generic.LWT.Payload }}"
+
+      # Quality of service level
+      qos={{ .Integration.MQTT.Auth.Generic.LWT.QOS }}
+
+      # Retain Message on broker for new subscriptions
+      retained={{ .Integration.MQTT.Auth.Generic.LWT.Retained }}
+
 
     # Google Cloud Platform Cloud IoT Core authentication.
     #

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -72,6 +72,14 @@ type Config struct {
 					QOS          uint8    `mapstructure:"qos"`
 					CleanSession bool     `mapstructure:"clean_session"`
 					ClientID     string   `mapstructure:"client_id"`
+
+					LWT struct {
+						Enable   bool   `mapstructure:"enable"`
+						Topic    string `mapstructure:"topic"`
+						Payload  string `mapstructure:"payload"`
+						QOS      uint8  `mapstructure:"qos"`
+						Retained bool   `mapstructure:"retained"`
+					} `mapstructure:"lwt"`
 				} `mapstructure:"generic"`
 
 				GCPCloudIoTCore struct {

--- a/internal/integration/mqtt/auth/generic.go
+++ b/internal/integration/mqtt/auth/generic.go
@@ -18,6 +18,12 @@ type GenericAuthentication struct {
 	cleanSession bool
 	clientID     string
 
+	lwtEnable   bool
+	lwtTopic    string
+	lwtPayload  string
+	lwtQOS      uint8
+	lwtRetained bool
+
 	tlsConfig *tls.Config
 }
 
@@ -39,6 +45,12 @@ func NewGenericAuthentication(conf config.Config) (Authentication, error) {
 		password:     conf.Integration.MQTT.Auth.Generic.Password,
 		cleanSession: conf.Integration.MQTT.Auth.Generic.CleanSession,
 		clientID:     conf.Integration.MQTT.Auth.Generic.ClientID,
+
+		lwtEnable:   conf.Integration.MQTT.Auth.Generic.LWT.Enable,
+		lwtTopic:    conf.Integration.MQTT.Auth.Generic.LWT.Topic,
+		lwtPayload:  conf.Integration.MQTT.Auth.Generic.LWT.Payload,
+		lwtQOS:      conf.Integration.MQTT.Auth.Generic.LWT.QOS,
+		lwtRetained: conf.Integration.MQTT.Auth.Generic.LWT.Retained,
 	}, nil
 }
 
@@ -51,6 +63,10 @@ func (a *GenericAuthentication) Init(opts *mqtt.ClientOptions) error {
 	opts.SetPassword(a.password)
 	opts.SetCleanSession(a.cleanSession)
 	opts.SetClientID(a.clientID)
+
+	if a.lwtEnable {
+		opts.SetWill(a.lwtTopic, a.lwtPayload, a.lwtQOS, a.lwtRetained)
+	}
 
 	if a.tlsConfig != nil {
 		opts.SetTLSConfig(a.tlsConfig)


### PR DESCRIPTION
Closes #117 

Add config options for the Generic MQTT integration to register an LWT message with the broker.

I used the `SetWill` function with a string payload rather than the `SetBinaryWill` as suggested in the original issue as I figured it would be more useful for the majority of users (who would probably just want to send some JSON or something anyway), and easier to use than having to configure a byte array in the config file.