### PR TITLE
Add rpm generation

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,6 +31,7 @@ nfpm:
   license: MIT
   formats:
     - deb
+    - rpm
   bindir: /usr/bin
   files:
     "packaging/files/chirpstack-gateway-bridge.rotate": "/etc/logrotate.d/chirpstack-gateway-bridge"

--- a/docs/content/overview/downloads.md
+++ b/docs/content/overview/downloads.md
@@ -50,6 +50,17 @@ sudo echo "deb https://artifacts.chirpstack.io/packages/3.x/deb stable main" | s
 sudo apt-get update
 {{< /highlight >}}
 
+## Redhat / Centos packages
+
+| File name                                                                                                                                                                  | OS      | Arch  |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------| ------- | ----- |
+| [chirpstack-gateway-bridge_{{< version >}}_linux_386.rpm](https://artifacts.chirpstack.io/downloads/chirpstack-gateway-bridge/chirpstack-gateway-bridge_{{< version >}}_linux_386.rpm)     | Linux   | 386   |
+| [chirpstack-gateway-bridge_{{< version >}}_linux_amd64.rpm](https://artifacts.chirpstack.io/downloads/chirpstack-gateway-bridge/chirpstack-gateway-bridge_{{< version >}}_linux_amd64.rpm) | Linux   | amd64 |
+| [chirpstack-gateway-bridge_{{< version >}}_linux_armv5.rpm](https://artifacts.chirpstack.io/downloads/chirpstack-gateway-bridge/chirpstack-gateway-bridge_{{< version >}}_linux_armv5.rpm) | Linux   | armv5 |
+| [chirpstack-gateway-bridge_{{< version >}}_linux_armv6.rpm](https://artifacts.chirpstack.io/downloads/chirpstack-gateway-bridge/chirpstack-gateway-bridge_{{< version >}}_linux_armv6.rpm) | Linux   | armv6 |
+| [chirpstack-gateway-bridge_{{< version >}}_linux_armv7.rpm](https://artifacts.chirpstack.io/downloads/chirpstack-gateway-bridge/chirpstack-gateway-bridge_{{< version >}}_linux_armv7.rpm) | Linux   | armv7 |
+| [chirpstack-gateway-bridge_{{< version >}}_linux_arm64.rpm](https://artifacts.chirpstack.io/downloads/chirpstack-gateway-bridge/chirpstack-gateway-bridge_{{< version >}}_linux_arm64.rpm) | Linux   | arm64 |
+
 ## Docker images
 
 For Docker images, please refer to https://hub.docker.com/r/chirpstack/chirpstack-gateway-bridge/.


### PR DESCRIPTION
- Add rpm to .goreleaser.yml
- Add rpm download links to downloads page

I have not been able to test the gateway bridge rpms, maybe it is not that useful to have rpms for it.