### PR TITLE
configurable keep alive for mqtt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,4 +44,4 @@ serve: build
 	./build/chirpstack-gateway-bridge
 
 run-compose-test:
-	docker-compose run --rm gatewaybridge make test
+	docker-compose run --rm chirpstack-gateway-bridge make test

--- a/cmd/chirpstack-gateway-bridge/cmd/configfile.go
+++ b/cmd/chirpstack-gateway-bridge/cmd/configfile.go
@@ -224,6 +224,11 @@ marshaler="{{ .Integration.Marshaler }}"
   # Command topic template.
   command_topic_template="{{ .Integration.MQTT.CommandTopicTemplate }}"
 
+  # Keep alive will set the amount of time (in seconds) that the client should
+  # wait before sending a PING request to the broker. This will allow the client
+  # to know that a connection has not been lost with the server.
+  keep_alive="{{ .Integration.MQTT.KeepAlive }}"
+
   # Maximum interval that will be waited between reconnection attempts when connection is lost.
   # Valid units are 'ms', 's', 'm', 'h'. Note that these values can be combined, e.g. '24h30m15s'.
   max_reconnect_interval="{{ .Integration.MQTT.MaxReconnectInterval }}"

--- a/cmd/chirpstack-gateway-bridge/cmd/root.go
+++ b/cmd/chirpstack-gateway-bridge/cmd/root.go
@@ -58,6 +58,7 @@ func init() {
 
 	viper.SetDefault("integration.mqtt.event_topic_template", "gateway/{{ .GatewayID }}/event/{{ .EventType }}")
 	viper.SetDefault("integration.mqtt.command_topic_template", "gateway/{{ .GatewayID }}/command/#")
+	viper.SetDefault("integration.mqtt.keep_alive", 30*time.Second)
 	viper.SetDefault("integration.mqtt.max_reconnect_interval", time.Minute)
 
 	viper.SetDefault("integration.mqtt.auth.generic.servers", []string{"tcp://127.0.0.1:1883"})

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -58,6 +58,7 @@ type Config struct {
 		MQTT struct {
 			EventTopicTemplate      string        `mapstructure:"event_topic_template"`
 			CommandTopicTemplate    string        `mapstructure:"command_topic_template"`
+			KeepAlive               time.Duration `mapstructure:"keep_alive"`
 			MaxReconnectInterval    time.Duration `mapstructure:"max_reconnect_interval"`
 			TerminateOnConnectError bool          `mapstructure:"terminate_on_connect_error"`
 

--- a/internal/integration/mqtt/backend.go
+++ b/internal/integration/mqtt/backend.go
@@ -128,6 +128,7 @@ func NewBackend(conf config.Config) (*Backend, error) {
 	b.clientOpts.SetAutoReconnect(true) // this is required for buffering messages in case offline!
 	b.clientOpts.SetOnConnectHandler(b.onConnected)
 	b.clientOpts.SetConnectionLostHandler(b.onConnectionLost)
+	b.clientOpts.SetKeepAlive(conf.Integration.MQTT.KeepAlive)
 	b.clientOpts.SetMaxReconnectInterval(conf.Integration.MQTT.MaxReconnectInterval)
 
 	if err = b.auth.Init(b.clientOpts); err != nil {


### PR DESCRIPTION
The keep alive interval for MQTT can be set using the configfile.

This is useful to optimize the data usage. It makes it possible to fine tune the data consumption when using cellular data.