### PR TITLE
Basic Station time synchronization.

### DIFF
--- a/internal/backend/basicstation/structs/msg_type.go
+++ b/internal/backend/basicstation/structs/msg_type.go
@@ -18,6 +18,7 @@ const (
 	ProprietaryDataFrameMessage MessageType = "propdf"
 	DownlinkMessage             MessageType = "dnmsg"
 	DownlinkTransmittedMessage  MessageType = "dntxed"
+	TimeSyncMessage             MessageType = "timesync"
 )
 
 type messageTypePayload struct {

--- a/internal/backend/basicstation/structs/time_sync.go
+++ b/internal/backend/basicstation/structs/time_sync.go
@@ -1,0 +1,14 @@
+package structs
+
+// TimeSyncRequest implements the router-info request.
+type TimeSyncRequest struct {
+	MessageType MessageType `json:"msgtype"`
+	TxTime      int64       `json:"txtime"`
+}
+
+// TimeSyncResponse implements the router-info response.
+type TimeSyncResponse struct {
+	MessageType MessageType `json:"msgtype"`
+	TxTime      int64       `json:"txtime"`
+	GPSTime     int64       `json:"gpstime"`
+}


### PR DESCRIPTION
Closes #179.

Supports request and response to the ["timesync" message type](https://doc.sm.tc/station/tcproto.html#synchronizing-pps-to-gps-time) of the LNS protocol.

Tested with a Cisco IXM and the gateway time is now provided in the uplink messages.