### PR TITLE
Respect terminate_on_connect when gateway bridge is running

### DIFF
--- a/internal/integration/mqtt/backend.go
+++ b/internal/integration/mqtt/backend.go
@@ -382,6 +382,9 @@ func (b *Backend) subscribeLoop() {
 }
 
 func (b *Backend) onConnectionLost(c paho.Client, err error) {
+	if b.terminateOnConnectError {
+		log.Fatal(err)
+	}
 	mqttDisconnectCounter().Inc()
 	log.WithError(err).Error("mqtt: connection error")
 }


### PR DESCRIPTION
The configuration terminate_on_connect_error=true only seems to apply when the gateway-bridge is starting up. If the gateway-bridge loses connection to the mqtt broker during runtime, it does not terminate.

This MR adds a check to the onConnectionLost handler to check if the user has terminateOnConnectError set and uses log.fatal to kill the service.

We will likely run this on our instance so I thought I would submit a PR here.
