### PR TITLE
don't run as root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,5 @@ FROM alpine:3 AS production
 
 RUN apk --no-cache add ca-certificates
 COPY --from=development /chirpstack-gateway-bridge/build/chirpstack-gateway-bridge /usr/bin/chirpstack-gateway-bridge
+USER nobody:nogroup
 ENTRYPOINT ["/usr/bin/chirpstack-gateway-bridge"]


### PR DESCRIPTION
It's a good practice to avoid running docker containers with root access

I currently have the app server deployed with a wrapping docker container performing the same

```dockerfile
FROM chirpstack/chirpstack-gateway-bridge:3.9.2
USER nobody:nogroup
ENTRYPOINT ["/usr/bin/chirpstack-gateway-bridge"]
```