### PR TITLE
Add support for port 80 in basics station

### DIFF
--- a/internal/backend/basicstation/backend.go
+++ b/internal/backend/basicstation/backend.go
@@ -322,11 +322,17 @@ func (b *Backend) handleRouterInfo(r *http.Request, c *websocket.Conn) {
 		}
 		return
 	}
+	
+	host := r.Host;
+
+	if !strings.Contains(host, ":") {
+		host = fmt.Sprintf("%s:%s", host, "80")
+	}
 
 	resp := structs.RouterInfoResponse{
 		Router: req.Router,
 		Muxs:   req.Router,
-		URI:    fmt.Sprintf("%s://%s/gateway/%s", b.scheme, r.Host, lorawan.EUI64(req.Router)),
+		URI:    fmt.Sprintf("%s://%s/gateway/%s", b.scheme, host, lorawan.EUI64(req.Router)),
 	}
 
 	if r.TLS != nil && len(r.TLS.PeerCertificates) > 0 {


### PR DESCRIPTION
The r.host drops the port information if it is port 80. This makes it so the gateways get the wrong router_config and can't connect properly.

Add a check for if the port doesn't exist, and if it doesn't default to port 80.