### PR TITLE
Fix: location not passed to MQTT from semtech_udp backend

### DIFF
--- a/internal/backend/semtechudp/backend.go
+++ b/internal/backend/semtechudp/backend.go
@@ -511,6 +511,7 @@ func (b *Backend) handleStats(gatewayID lorawan.EUI64, stats gw.GatewayStats) {
 		stats.RxPacketsPerModulation = s.RxPacketsPerModulation
 		stats.TxPacketsPerModulation = s.TxPacketsPerModulation
 		stats.TxPacketsPerStatus = s.TxPacketsPerStatus
+		stats.Location = s.Location
 	}
 
 	if b.gatewayStatsFunc != nil {

--- a/internal/backend/semtechudp/backend.go
+++ b/internal/backend/semtechudp/backend.go
@@ -511,7 +511,6 @@ func (b *Backend) handleStats(gatewayID lorawan.EUI64, stats gw.GatewayStats) {
 		stats.RxPacketsPerModulation = s.RxPacketsPerModulation
 		stats.TxPacketsPerModulation = s.TxPacketsPerModulation
 		stats.TxPacketsPerStatus = s.TxPacketsPerStatus
-		stats.Location = s.Location
 	}
 
 	if b.gatewayStatsFunc != nil {

--- a/internal/backend/semtechudp/packets/push_data.go
+++ b/internal/backend/semtechudp/packets/push_data.go
@@ -71,7 +71,7 @@ func (p PushDataPacket) GetGatewayStats() (*gw.GatewayStats, error) {
 	stats.Time = ts
 
 	// location
-	if p.Payload.Stat.Lati != 0 && p.Payload.Stat.Long != 0 && p.Payload.Stat.Alti != 0 {
+	if p.Payload.Stat.Lati != 0 || p.Payload.Stat.Long != 0 || p.Payload.Stat.Alti != 0 {
 		stats.Location = &common.Location{
 			Latitude:  p.Payload.Stat.Lati,
 			Longitude: p.Payload.Stat.Long,


### PR DESCRIPTION
It is very small fix - when processing `push data` received from `udp` in `semtech_udp` backend, the location is lost.

in `backend.go` - location just is not copied between two data objects when copying other fields, in `handleStats`. we can clone it here rather than assign, but since it was freshly created, this makes no difference.

in `push_data.go` we obviously wanted to check if the whole structure was decoded from JSON and has any non-zero fields, we need `OR` aggregation here rather than `AND` - otherwise location is not copied for example if `Altitude = 0` which may happen in gateway simulator or even in real device if the field is ignored.